### PR TITLE
Absolutely prevent debconf from going interactive

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -77,6 +77,8 @@ install_apt_deps() {
   if ! test "$missing"; then return; fi
 
   # Install the Apt dependencies now
+  export DEBIAN_FRONTEND='noninteractive'
+  export DEBCONF_NONINTERACTIVE_SEEN='true'
   apt-get -qq update || warn "apt-get update failed ... attempting package install anyways"
   dry_exec apt-get -qq install $missing
 }


### PR DESCRIPTION
Absolutely prevent debconf from interrupting the script run by going interactive/ncurses.

Attempts to prefix apt-get command with the vars, as opposed to an export, were insufficient so falling back to Big Hammer 'export'.

@diranged 